### PR TITLE
Fix --optimizer cuopt: unblock from Gurobi license, fix solver-settings type error

### DIFF
--- a/compass/main.py
+++ b/compass/main.py
@@ -503,8 +503,8 @@ def entry():
 
     args = parseArgs()
 
-    if (not args['set_license']) and (not os.path.exists(os.path.join(globals.LICENSE_DIR, 'gurobi.lic'))):
-        print('A Gurobi license is required to run Compass. Run Compass again with \'--set-license <PATH_TO_LICENSE>\' to save license.')
+    if (args['optimizer'] == 'gurobi') and (not args['set_license']) and (not os.path.exists(os.path.join(globals.LICENSE_DIR, 'gurobi.lic'))):
+        print('A Gurobi license is required to run Compass with --optimizer gurobi. Run Compass again with \'--set-license <PATH_TO_LICENSE>\' to save license, or select a different --optimizer.')
         return
     elif args['set_license']:
 

--- a/compass/opt/cuopt.py
+++ b/compass/opt/cuopt.py
@@ -91,8 +91,10 @@ def get_cuopt_config(threads: int | None = None, method: int | None = None) -> d
         method = 0
     return {
         # N.B. cuopt does not actually respect this flag, but should be resolved in coming PR
-        CUOPT_LOG_TO_CONSOLE: False,
-        CUOPT_PRESOLVE: False,
+        # cuopt-cu12's solver_settings setter rejects Python bool (Cython's int check
+        # excludes the bool subtype), so these must be plain ints, not True/False.
+        CUOPT_LOG_TO_CONSOLE: int(False),
+        CUOPT_PRESOLVE: int(False),
         CUOPT_NUM_CPU_THREADS: threads,
         # TODO: NVIDIA does not really explain these, but their docs indicate stable3 is generally the best
         CUOPT_PDLP_SOLVER_MODE: PDLPSolverMode.Stable3,
@@ -100,7 +102,7 @@ def get_cuopt_config(threads: int | None = None, method: int | None = None) -> d
         # The methods are concurrent, pdlp, dual simplex, barrier enumerated as 0,1,2,3
         CUOPT_METHOD: method,
         # Determinism is preferrable for replication.
-        CUOPT_CUDSS_DETERMINISTIC: True,
+        CUOPT_CUDSS_DETERMINISTIC: int(True),
         # Each problem should take well under 120 seconds.
         CUOPT_TIME_LIMIT: 120,
     }


### PR DESCRIPTION
Fixes #35.

Two small fixes needed to actually get `--optimizer cuopt` working end to end, without touching Gurobi at all:

1. **License gate.** `main.py`'s license check ran regardless of `--optimizer`, so `--optimizer cuopt` was blocked by a missing `gurobi.lic` even though the cuOpt backend never touches Gurobi. Gated the check on `args['optimizer'] == 'gurobi'` — Gurobi runs still require the license exactly as before; `cuopt` runs no longer need one.

2. **cuOpt solver-settings type mismatch.** `compass/opt/cuopt.py`'s `get_cuopt_config()` passes `CUOPT_PRESOLVE`, `CUOPT_LOG_TO_CONSOLE`, and `CUOPT_CUDSS_DETERMINISTIC` as Python `bool`. With `cuopt-cu12==26.8.0`, `SolverSettings.set_c_solver_settings` rejects `bool` for these integer-typed parameters (its type check excludes the `bool` subtype, even though `bool` is an `int` subclass in plain Python), failing every real solve with `ValueError: Parameter presolve value False is not an integer`. Cast these to `int` at the call site.

With both applied, `compass --optimizer cuopt --data ... --species mus_musculus` runs a real FBA solve on GPU with no Gurobi license file anywhere on the host — verified against the bundled `Resources/Test-Data/tsv_format/expression.tsv`.
